### PR TITLE
feat(parser): Group transactions by card in Bradesco parser

### DIFF
--- a/statement_ingestor/bradesco_credit_card_parser.py
+++ b/statement_ingestor/bradesco_credit_card_parser.py
@@ -14,17 +14,21 @@ class BradescoCreditCardParser(BaseParser):
         due_date = _extract_due_date(lines)
 
         transactions = []
-        account_id = "bradesco_credit_card_0000"  # Dummy account ID
+        current_card_number = "0000"  # Default card number
 
         for line in lines:
+            if card_number := _extract_card_number(line):
+                current_card_number = card_number
+
             if _is_transaction_line(line):
+                account_id = f"bradesco_credit_card_{current_card_number}"
                 transaction = _parse_transaction(line, account_id, due_date)
                 if transaction:
                     transactions.append(transaction)
 
         if not transactions:
             return Statement(
-                account_id=account_id,
+                account_id="bradesco_credit_card_multi",
                 account_type=AccountType.CREDIT_CARD,
                 transactions=[],
                 start_date=None,
@@ -35,7 +39,7 @@ class BradescoCreditCardParser(BaseParser):
         end_date = max(t.date for t in transactions)
 
         return Statement(
-            account_id=account_id,
+            account_id="bradesco_credit_card_multi",
             account_type=AccountType.CREDIT_CARD,
             transactions=transactions,
             start_date=start_date,

--- a/tests/test_bradesco_credit_card.py
+++ b/tests/test_bradesco_credit_card.py
@@ -13,7 +13,7 @@ from datetime import datetime, date
 def test_ingest_statement():
     mock_pdf_content = [
         "Data de Vencimento Total da Fatura R$",
-        "01/01/2025 100,00",
+        "VENCIMENTO 01/04/2025",
         "JOHN DOE Cartão 4066 XXXX XXXX 1234",
         "06/03 PAG BOLETO BANCARIO 1.234,56-",
         "07/03 COMPRA TESTE 100,00",
@@ -29,7 +29,7 @@ def test_ingest_statement():
         statement = parser.parse("dummy.pdf")
 
         assert isinstance(statement, Statement)
-        assert statement.account_id == "bradesco_credit_card_0000"
+        assert statement.account_id == "bradesco_credit_card_multi"
         assert statement.account_type == AccountType.CREDIT_CARD
         assert statement.start_date == date(2025, 3, 6)
         assert statement.end_date == date(2025, 3, 8)
@@ -41,25 +41,28 @@ def test_ingest_statement():
                 description="PAG BOLETO BANCARIO",
                 amount=-1234.56,
                 currency="BRL",
-                account_id="bradesco_credit_card_0000",
+                account_id="bradesco_credit_card_1234",
             ),
             Transaction(
                 date=date(2025, 3, 7),
                 description="COMPRA TESTE",
                 amount=100.00,
                 currency="BRL",
-                account_id="bradesco_credit_card_0000",
+                account_id="bradesco_credit_card_1234",
             ),
             Transaction(
                 date=date(2025, 3, 8),
                 description="OUTRA COMPRA",
                 amount=50.00,
                 currency="BRL",
-                account_id="bradesco_credit_card_0000",
+                account_id="bradesco_credit_card_5678",
             ),
         ]
 
-        assert statement.transactions == expected_transactions
+        # Sort both lists to ensure comparison is order-independent
+        assert sorted(statement.transactions, key=lambda t: t.date) == sorted(
+            expected_transactions, key=lambda t: t.date
+        )
 
 
 def test_ingest_statement_empty(tmp_path):
@@ -74,7 +77,7 @@ def test_ingest_statement_empty(tmp_path):
         statement = parser.parse(str(empty_file))
 
         assert isinstance(statement, Statement)
-        assert statement.account_id == "bradesco_credit_card_0000"
+        assert statement.account_id == "bradesco_credit_card_multi"
         assert statement.account_type == AccountType.CREDIT_CARD
         assert statement.transactions == []
         assert statement.start_date is None


### PR DESCRIPTION
This change updates the `BradescoCreditCardParser` to identify the credit card number for each transaction and include it in the transaction's `account_id`.

The parser now returns a single `Statement` object containing all transactions from all cards, with a generic `account_id` for the statement itself.